### PR TITLE
JWT decode audience implementation

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -26,4 +26,5 @@ You can change many options for how this extension works via
                                   such as ``RS*`` or ``ES*``. PEM format expected.
 ``JWT_IDENTITY_CLAIM``            Which claim the `get_jwt_identity()` function will use to get
                                   the identity out of a JWT. Defaults to ``'sub'``.
+``JWT_DECODE_AUDIENCE``           The audience expected to be set in the JWT token when it is decoded.                                  
 ================================= =========================================

--- a/flask_jwt_simple/config.py
+++ b/flask_jwt_simple/config.py
@@ -60,6 +60,10 @@ class _Config(object):
         return current_app.config['JWT_ALGORITHM']
 
     @property
+    def audience(self):
+        return current_app.config['JWT_DECODE_AUDIENCE']
+
+    @property
     def _secret_key(self):
         key = current_app.config['JWT_SECRET_KEY']
         if not key:

--- a/flask_jwt_simple/jwt_manager.py
+++ b/flask_jwt_simple/jwt_manager.py
@@ -96,6 +96,9 @@ class JWTManager(object):
         # Key that acts as the identity for the JWT
         app.config.setdefault('JWT_IDENTITY_CLAIM', 'sub')
 
+        # Expected value of the audience claim
+        app.config.setdefault('JWT_DECODE_AUDIENCE', None)
+
         # Secret key to sign JWTs with. Only used if a symmetric algorithm is
         # used (such as the HS* algorithms).
         app.config.setdefault('JWT_SECRET_KEY', None)

--- a/flask_jwt_simple/utils.py
+++ b/flask_jwt_simple/utils.py
@@ -40,7 +40,8 @@ def decode_jwt(encoded_token):
     """
     secret = config.decode_key
     algorithm = config.algorithm
-    return jwt.decode(encoded_token, secret, algorithms=[algorithm])
+    audience = config.audience
+    return jwt.decode(encoded_token, secret, algorithms=[algorithm], audience=audience)
 
 
 def create_jwt(identity):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ def test_default_configs(app):
         assert config.jwt_expires == datetime.timedelta(hours=1)
         assert config.algorithm == 'HS256'
         assert config.identity_claim == 'sub'
+        assert config.audience is None
         with pytest.raises(RuntimeError):
             config.encode_key
         with pytest.raises(RuntimeError):
@@ -68,6 +69,9 @@ def test_config_overrides(app):
         app.config['JWT_ALGORITHM'] = 'RS256'
         assert config.algorithm == 'RS256'
         assert config.is_asymmetric is True
+
+        app.config['JWT_DECODE_AUDIENCE'] = 'foobar'
+        assert config.audience == 'foobar'
 
 
 # noinspection PyStatementEffect


### PR DESCRIPTION
This implements the configuration item `JWT_DECODE_AUDIENCE` to allow the user to specify an audience to the underlying `jwt.decode()` parameter.  

It passes the tests that I can run with `tox` (Python 3.6).  I've added some simple documentation but you might be able to word this better.

Disclaimer: I'm not a Python dev!